### PR TITLE
feat(golang): add table registry namespace

### DIFF
--- a/docs/tables/scaleway_registry_namespace.md
+++ b/docs/tables/scaleway_registry_namespace.md
@@ -11,7 +11,7 @@ select
   name,
   id,
   status,
-  created_date,
+  created_at,
   region,
   project,
   organization
@@ -26,12 +26,12 @@ select
   name,
   id,
   status,
-  created_date,
+  created_at,
   region,
   project,
   organization
 from
-  scaleway_registry_namespace;
+  scaleway_registry_namespace
 where
   is_public = true;
 ```

--- a/docs/tables/scaleway_registry_namespace.md
+++ b/docs/tables/scaleway_registry_namespace.md
@@ -1,0 +1,38 @@
+# Table: scaleway_registry_namespace
+
+Namespaces allow you to manage your Container Registry in a simple, clear and human-readable way.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  id,
+  status,
+  created_date,
+  region,
+  project,
+  organization
+from
+  scaleway_registry_namespace;
+```
+
+### List public registry namespace
+
+```sql
+select
+  name,
+  id,
+  status,
+  created_date,
+  region,
+  project,
+  organization
+from
+  scaleway_registry_namespace;
+where
+  is_public = true;
+```
+

--- a/docs/tables/scaleway_registry_namespace.md
+++ b/docs/tables/scaleway_registry_namespace.md
@@ -19,7 +19,7 @@ from
   scaleway_registry_namespace;
 ```
 
-### List public registry namespace
+### List public registry namespaces
 
 ```sql
 select

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.40.58
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.10
 	github.com/turbot/go-kit v0.4.0
 	github.com/turbot/steampipe-plugin-sdk/v4 v4.1.8
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1

--- a/go.sum
+++ b/go.sum
@@ -392,6 +392,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7 h1:Do8ksLD4Nr3pA0x0hnLOLftZgkiTDvwPDShRTUxtXpE=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7/go.mod h1:CJJ5VAbozOl0yEw7nHB9+7BXTJbIn6h7W+f6Gau5IP8=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.10 h1:wsfMs0iv+MJiViM37qh5VEKISi3/ZUq2nNKNdqmumAs=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.10/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sethvargo/go-retry v0.1.0 h1:8sPqlWannzcReEcYjHSNw9becsiYudcwTD7CasGjQaI=
 github.com/sethvargo/go-retry v0.1.0/go.mod h1:JzIOdZqQDNpPkQDmcqgtteAcxFLtYpNF/zJCM1ysDg8=

--- a/scaleway/plugin.go
+++ b/scaleway/plugin.go
@@ -30,7 +30,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"scaleway_object_bucket":           tableScalewayObjectBucket(ctx),
 			"scaleway_rdb_database":            tableScalewayRDBDatabase(ctx),
 			"scaleway_rdb_instance":            tableScalewayRDBInstance(ctx),
-			"scaleway_registry_namespace":	tableScalewayRegistryNamespace(ctx),
+			"scaleway_registry_namespace":      tableScalewayRegistryNamespace(ctx),
 			"scaleway_vpc_private_network":     tableScalewayVPCPrivateNetwork(ctx),
 		},
 	}

--- a/scaleway/plugin.go
+++ b/scaleway/plugin.go
@@ -30,7 +30,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"scaleway_object_bucket":           tableScalewayObjectBucket(ctx),
 			"scaleway_rdb_database":            tableScalewayRDBDatabase(ctx),
 			"scaleway_rdb_instance":            tableScalewayRDBInstance(ctx),
-			"scaleway_registry_namespace":		tableScalewayRegistryNamespace(ctx),
+			"scaleway_registry_namespace":	tableScalewayRegistryNamespace(ctx),
 			"scaleway_vpc_private_network":     tableScalewayVPCPrivateNetwork(ctx),
 		},
 	}

--- a/scaleway/plugin.go
+++ b/scaleway/plugin.go
@@ -30,6 +30,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"scaleway_object_bucket":           tableScalewayObjectBucket(ctx),
 			"scaleway_rdb_database":            tableScalewayRDBDatabase(ctx),
 			"scaleway_rdb_instance":            tableScalewayRDBInstance(ctx),
+			"scaleway_registry_namespace":		tableScalewayRegistryNamespace(ctx),
 			"scaleway_vpc_private_network":     tableScalewayVPCPrivateNetwork(ctx),
 		},
 	}

--- a/scaleway/table_scaleway_registry_namespace.go
+++ b/scaleway/table_scaleway_registry_namespace.go
@@ -71,7 +71,7 @@ func tableScalewayRegistryNamespace(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "size",
-				Description: "total size of the namespace, calculated as the sum of the size of all images in the namespace.",
+				Description: "Total size of the namespace, calculated as the sum of the size of all images in the namespace.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("Size").Transform(transform.ToString),
 			},

--- a/scaleway/table_scaleway_registry_namespace.go
+++ b/scaleway/table_scaleway_registry_namespace.go
@@ -78,8 +78,8 @@ func tableScalewayRegistryNamespace(_ context.Context) *plugin.Table {
 			{
 				Name:        "size",
 				Description: "Total size of the namespace, calculated as the sum of the size of all images in the namespace.",
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Size").Transform(transform.ToString),
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("Size").Transform(transform.ToInt),
 			},
 			{
 				Name:        "created_at",

--- a/scaleway/table_scaleway_registry_namespace.go
+++ b/scaleway/table_scaleway_registry_namespace.go
@@ -47,6 +47,12 @@ func tableScalewayRegistryNamespace(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "id",
+				Description: "An unique identifier of the instance.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ID"),
+			},
+			{
 				Name:        "status",
 				Description: "The current status of the namespace.",
 				Type:        proto.ColumnType_STRING,

--- a/scaleway/table_scaleway_registry_namespace.go
+++ b/scaleway/table_scaleway_registry_namespace.go
@@ -19,7 +19,7 @@ func tableScalewayRegistryNamespace(_ context.Context) *plugin.Table {
 		Description:       "Registry Namespaces allow you to manage your Container Registry in Scaleway.",
 		GetMatrixItemFunc: BuildRegionList,
 		List: &plugin.ListConfig{
-			Hydrate: listRegistryNamespace,
+			Hydrate: listRegistryNamespaces,
 			KeyColumns: []*plugin.KeyColumn{
 				{
 					Name:    "name",
@@ -32,7 +32,7 @@ func tableScalewayRegistryNamespace(_ context.Context) *plugin.Table {
 			},
 		},
 		Get: &plugin.GetConfig{
-			Hydrate:    getRegsitryNamespace,
+			Hydrate:    getRegistryNamespace,
 			KeyColumns: plugin.AllColumns([]string{"id", "region"}),
 		},
 		Columns: []*plugin.Column{
@@ -129,12 +129,12 @@ func tableScalewayRegistryNamespace(_ context.Context) *plugin.Table {
 
 //// LIST FUNCTION
 
-func listRegistryNamespace(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+func listRegistryNamespaces(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	region := plugin.GetMatrixItem(ctx)["region"].(string)
 
 	parseRegionData, err := scw.ParseRegion(region)
 	if err != nil {
-		plugin.Logger(ctx).Error("scaleway_regsitry_namespace.listRegsitryNamespace", "region_parsing_error", err)
+		plugin.Logger(ctx).Error("scaleway_registry_namespace.listRegistryNamespaces", "region_parsing_error", err)
 		return nil, err
 	}
 
@@ -146,7 +146,7 @@ func listRegistryNamespace(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	// Create client
 	client, err := getSessionConfig(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("scaleway_regsitry_namespace.listRegsitryNamespace", "connection_error", err)
+		plugin.Logger(ctx).Error("scaleway_registry_namespace.listRegistryNamespaces", "connection_error", err)
 		return nil, err
 	}
 
@@ -179,7 +179,7 @@ func listRegistryNamespace(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	for {
 		resp, err := registryApi.ListNamespaces(req)
 		if err != nil {
-			plugin.Logger(ctx).Error("scaleway_regsitry_namespace.listRegsitryNamespace", "query_error", err)
+			plugin.Logger(ctx).Error("scaleway_registry_namespace.listRegistryNamespaces", "query_error", err)
 			return nil, err
 		}
 
@@ -206,12 +206,12 @@ func listRegistryNamespace(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 
 //// HYDRATE FUNCTIONS
 
-func getRegsitryNamespace(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+func getRegistryNamespace(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := plugin.GetMatrixItem(ctx)["region"].(string)
 
 	parseRegionData, err := scw.ParseRegion(region)
 	if err != nil {
-		plugin.Logger(ctx).Error("scaleway_regsitry_namespace.getRegsitryNamespace", "region_parsing_error", err)
+		plugin.Logger(ctx).Error("scaleway_registry_namespace.getRegistryNamespace", "region_parsing_error", err)
 		return nil, err
 	}
 
@@ -222,7 +222,7 @@ func getRegsitryNamespace(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	// Create client
 	client, err := getSessionConfig(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("scaleway_regsitry_namespace.getRegsitryNamespace", "connection_error", err)
+		plugin.Logger(ctx).Error("scaleway_registry_namespace.getRegistryNamespace", "connection_error", err)
 		return nil, err
 	}
 
@@ -242,7 +242,7 @@ func getRegsitryNamespace(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		Region:      parseRegionData,
 	})
 	if err != nil {
-		plugin.Logger(ctx).Error("scaleway_regsitry_namespace.getRegsitryNamespace", "query_error", err)
+		plugin.Logger(ctx).Error("scaleway_registry_namespace.getRegistryNamespace", "query_error", err)
 		if is404Error(err) {
 			return nil, nil
 		}

--- a/scaleway/table_scaleway_registry_namespace.go
+++ b/scaleway/table_scaleway_registry_namespace.go
@@ -1,0 +1,247 @@
+package scaleway
+
+import (
+	"context"
+
+	"github.com/scaleway/scaleway-sdk-go/api/registry/v1"
+
+	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableScalewayRegistryNamespace(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:              "scaleway_registry_namespace",
+		Description:       "Registry Namespaces allow you to manage your Container Registry in Scaleway.",
+		GetMatrixItemFunc: BuildRegionList,
+		List: &plugin.ListConfig{
+			Hydrate: listRegistryNamespace,
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "name",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "region",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		Get: &plugin.GetConfig{
+			Hydrate:    getRegsitryNamespace,
+			KeyColumns: plugin.AllColumns([]string{"id", "region"}),
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "name",
+				Description: "The user-defined name of the namespace.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "description",
+				Description: "A description of the namespace.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "status",
+				Description: "The current status of the namespace.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Status").Transform(transform.ToString),
+			},
+			{
+				Name:        "status_message",
+				Description: "The current status of the namespace.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("StatusMessage").Transform(transform.ToString),
+			},
+			{
+				Name:        "endpoint",
+				Description: "The endpoint reachable by docker of the namespace.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "is_public",
+				Description: "The namespace visibility policy.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromField("IsPublic").Transform(transform.ToBool),
+			},
+			{
+				Name:        "size",
+				Description: "total size of the namespace, calculated as the sum of the size of all images in the namespace.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Size").Transform(transform.ToString),
+			},
+			{
+				Name:        "created_at",
+				Description: "The time when the namespace was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "updated_at",
+				Description: "The time when the namespace was updated.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "image_count",
+				Description: "The number of images in the namespace.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("ImageCount").Transform(transform.ToInt),
+			},
+			{
+				Name:        "region",
+				Description: "Specifies the region where the namespace.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Region").Transform(transform.ToString),
+			},
+
+			// Scaleway standard columns
+			{
+				Name:        "project",
+				Description: "The ID of the project where the namespace resides.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "organization",
+				Description: "The ID of the organization where the namespace resides.",
+				Type:        proto.ColumnType_STRING,
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: "Title of the resource.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listRegistryNamespace(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	region := plugin.GetMatrixItem(ctx)["region"].(string)
+
+	parseRegionData, err := scw.ParseRegion(region)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_regsitry_namespace.listRegsitryNamespace", "region_parsing_error", err)
+		return nil, err
+	}
+
+	quals := d.KeyColumnQuals
+	if quals["region"] != nil && quals["region"].GetStringValue() != region {
+		return nil, nil
+	}
+
+	// Create client
+	client, err := getSessionConfig(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_regsitry_namespace.listRegsitryNamespace", "connection_error", err)
+		return nil, err
+	}
+
+	// Create SDK objects for Scaleway Registry product
+	registryApi := registry.NewAPI(client)
+
+	req := &registry.ListNamespacesRequest{
+		Region: parseRegionData,
+		Page:   scw.Int32Ptr(1),
+	}
+	// Additional filters
+	if quals["name"] != nil {
+		req.Name = scw.StringPtr(quals["name"].GetStringValue())
+	}
+
+	// Retrieve the list of namespaces
+	maxResult := int64(100)
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < maxResult {
+			maxResult = *limit
+		}
+	}
+	req.PageSize = scw.Uint32Ptr(uint32(maxResult))
+
+	var count int
+
+	for {
+		resp, err := registryApi.ListNamespaces(req)
+		if err != nil {
+			plugin.Logger(ctx).Error("scaleway_regsitry_namespace.listRegsitryNamespace", "query_error", err)
+			return nil, err
+		}
+
+		for _, namespace := range resp.Namespaces {
+			d.StreamListItem(ctx, namespace)
+
+			// Increase the resource count by 1
+			count++
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+
+		if resp.TotalCount == uint32(count) {
+			break
+		}
+		req.Page = scw.Int32Ptr(*req.Page + 1)
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getRegsitryNamespace(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	region := plugin.GetMatrixItem(ctx)["region"].(string)
+
+	parseRegionData, err := scw.ParseRegion(region)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_regsitry_namespace.getRegsitryNamespace", "region_parsing_error", err)
+		return nil, err
+	}
+
+	if d.KeyColumnQuals["region"].GetStringValue() != region {
+		return nil, nil
+	}
+
+	// Create client
+	client, err := getSessionConfig(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_regsitry_namespace.getRegsitryNamespace", "connection_error", err)
+		return nil, err
+	}
+
+	// Create SDK objects for Scaleway Registry product
+	registryApi := registry.NewAPI(client)
+
+	id := d.KeyColumnQuals["id"].GetStringValue()
+	RegistryRegion := d.KeyColumnQuals["region"].GetStringValue()
+
+	// No inputs
+	if id == "" && RegistryRegion == "" {
+		return nil, nil
+	}
+
+	data, err := registryApi.GetNamespace(&registry.GetNamespaceRequest{
+		NamespaceID: id,
+		Region:      parseRegionData,
+	})
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_regsitry_namespace.getRegsitryNamespace", "query_error", err)
+		if is404Error(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/scaleway/table_scaleway_registry_namespace.go
+++ b/scaleway/table_scaleway_registry_namespace.go
@@ -93,7 +93,7 @@ func tableScalewayRegistryNamespace(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "region",
-				Description: "Specifies the region where the namespace.",
+				Description: "Specifies the region where the namespace is located.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("Region").Transform(transform.ToString),
 			},

--- a/scaleway/table_scaleway_registry_namespace.go
+++ b/scaleway/table_scaleway_registry_namespace.go
@@ -48,7 +48,7 @@ func tableScalewayRegistryNamespace(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "id",
-				Description: "An unique identifier of the instance.",
+				Description: "A unique identifier of the instance.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("ID"),
 			},


### PR DESCRIPTION
Description
Add table_scaleway_registry_namespacetable to scaleway plugin, allowing list and get on registry namespace.

I need a person to test this table ! Else i test this in ~2-3 weeks..

# Example query results

```sql
select
  name,
  id,
  status,
  created_at,
  region,
  project,
  organization
from
  scaleway_registry_namespace
where
  is_public = true;
```

<details>
  <summary>Results</summary>
```
> select
  name,
  id,
  status,
  created_at,
  region,
  project,
  organization
from
  scaleway_registry_namespace
where
  is_public = true;
+---------------------+--------------------------------------+--------+---------------------------+--------+---------+--------------+
| name                | id                                   | status | created_at                | region | project | organization |
+---------------------+--------------------------------------+--------+---------------------------+--------+---------+--------------+
| namespace-amsterdam | 6cf7ef0c-f950-4f5e-a3b4-c757954e645b | ready  | 2022-12-08T10:22:10+01:00 | nl-ams | <null>  | <null>       |
+---------------------+--------------------------------------+--------+---------------------------+--------+---------+--------------+
```
</details>
