### PR TITLE
Add table scaleway_registry_image

### DIFF
--- a/docs/tables/scaleway_registry_image.md
+++ b/docs/tables/scaleway_registry_image.md
@@ -1,0 +1,36 @@
+# Table: scaleway_registry_namespace
+
+Namespaces allow you to manage your Container Registry in a simple, clear and human-readable way.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  id,
+  status,
+  created_at,
+  tags,
+  size
+from
+  scaleway_registry_image;
+```
+
+### List images updated in last 10 days for a repository
+
+```sql
+select
+  name,
+  id,
+  status,
+  created_at,
+  updated_at
+  tags,
+  size
+from
+  scaleway_registry_image
+where
+  updated_at >= now() - interval '10' day
+```

--- a/docs/tables/scaleway_registry_image.md
+++ b/docs/tables/scaleway_registry_image.md
@@ -34,3 +34,21 @@ from
 where
   updated_at >= now() - interval '10' day
 ```
+
+
+### List images with a public visibility
+
+```sql
+select
+  name,
+  id,
+  status,
+  created_at,
+  updated_at
+  tags,
+  visibility
+from
+  scaleway_registry_image
+where
+  visibility = 'public'
+```

--- a/scaleway/plugin.go
+++ b/scaleway/plugin.go
@@ -30,6 +30,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"scaleway_object_bucket":           tableScalewayObjectBucket(ctx),
 			"scaleway_rdb_database":            tableScalewayRDBDatabase(ctx),
 			"scaleway_rdb_instance":            tableScalewayRDBInstance(ctx),
+			"scaleway_registry_image":          tableScalewayRegistryImage(ctx),
 			"scaleway_registry_namespace":      tableScalewayRegistryNamespace(ctx),
 			"scaleway_vpc_private_network":     tableScalewayVPCPrivateNetwork(ctx),
 		},

--- a/scaleway/table_scaleway_registry_image.go
+++ b/scaleway/table_scaleway_registry_image.go
@@ -1,0 +1,245 @@
+package scaleway
+
+import (
+	"context"
+
+	"github.com/scaleway/scaleway-sdk-go/api/registry/v1"
+
+	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableScalewayRegistryImage(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:              "scaleway_registry_image",
+		Description:       "Registry Images allow you to manage your docker images in Scaleway.",
+		GetMatrixItemFunc: BuildRegionList,
+		List: &plugin.ListConfig{
+			Hydrate:       listRegistryImages,
+			ParentHydrate: listRegistryNamespaces,
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "name",
+					Require: plugin.Optional,
+				}, {
+					Name:    "namespace_id",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		Get: &plugin.GetConfig{
+			Hydrate:    getRegistryImage,
+			KeyColumns: plugin.AllColumns([]string{"id"}),
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "name",
+				Description: "The Image name, unique in a namespace",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "namespace_id",
+				Description: "The unique ID of the Namespace the image belongs to",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("NamespaceID"),
+			},
+			{
+				Name:        "id",
+				Description: "A unique identifier of the instance.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ID"),
+			},
+			{
+				Name:        "status",
+				Description: "The current status of the Image.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Status").Transform(transform.ToString),
+			},
+			{
+				Name:        "visibility",
+				Description: "A `public` image is pullable from internet without authentication, opposed to a `private` image. `inherit` will use the namespace `is_public` parameter.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Visibility").Transform(transform.ToString),
+			},
+			{
+				Name:        "size",
+				Description: "Image size in bytes, calculated from the size of image layers. One layer used in two tags of the same image is counted once but one layer used in two images is counted twice.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("Size").Transform(transform.ToInt),
+			},
+			{
+				Name:        "created_at",
+				Description: "The time when the Image was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "updated_at",
+				Description: "The time when the Image was updated.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "tags",
+				Description: "A list of tags attached with the docker image.",
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// Scaleway standard columns
+			{
+				Name:        "project",
+				Description: "The ID of the project where the Image resides.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "organization",
+				Description: "The ID of the organization where the Image resides.",
+				Type:        proto.ColumnType_STRING,
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: "Title of the resource.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
+		},
+	}
+}
+
+type imageInfo = struct {
+	registry.Image
+	InstanceID   string
+	Region       scw.Region
+	Project      string
+	Organization string
+}
+
+//// LIST FUNCTION
+
+func listRegistryImages(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	region := plugin.GetMatrixItem(ctx)["region"].(string)
+
+	parseRegionData, err := scw.ParseRegion(region)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_registry_Image.listRegistryImages", "region_parsing_error", err)
+		return nil, err
+	}
+
+	// Get Namespace details
+	namespaceData := h.Item.(*registry.Namespace)
+
+	quals := d.KeyColumnQuals
+
+	// Create client
+	client, err := getSessionConfig(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_registry_Image.listRegistryImages", "connection_error", err)
+		return nil, err
+	}
+
+	// Create SDK objects for Scaleway Registry product
+	registryApi := registry.NewAPI(client)
+
+	req := &registry.ListImagesRequest{
+		Region:      parseRegionData,
+		NamespaceID: &namespaceData.ID,
+		Page:        scw.Int32Ptr(1),
+	}
+	// Additional filters
+	if quals["name"] != nil {
+		req.Name = scw.StringPtr(quals["name"].GetStringValue())
+	}
+
+	// Retrieve the list of Images
+	maxResult := int64(100)
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < maxResult {
+			maxResult = *limit
+		}
+	}
+	req.PageSize = scw.Uint32Ptr(uint32(maxResult))
+
+	var count int
+
+	for {
+		resp, err := registryApi.ListImages(req)
+		if err != nil {
+			plugin.Logger(ctx).Error("scaleway_registry_Image.listRegistryImages", "query_error", err)
+			return nil, err
+		}
+
+		for _, image := range resp.Images {
+			d.StreamListItem(ctx, imageInfo{*image, namespaceData.ID, namespaceData.Region, namespaceData.ProjectID, namespaceData.OrganizationID})
+
+			// Increase the resource count by 1
+			count++
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+
+		if resp.TotalCount == uint32(count) {
+			break
+		}
+		req.Page = scw.Int32Ptr(*req.Page + 1)
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getRegistryImage(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	region := plugin.GetMatrixItem(ctx)["region"].(string)
+
+	parseRegionData, err := scw.ParseRegion(region)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_registry_Image.getRegistryImage", "region_parsing_error", err)
+		return nil, err
+	}
+
+	if d.KeyColumnQuals["region"].GetStringValue() != region {
+		return nil, nil
+	}
+
+	// Create client
+	client, err := getSessionConfig(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_registry_Image.getRegistryImage", "connection_error", err)
+		return nil, err
+	}
+
+	// Create SDK objects for Scaleway Registry product
+	registryApi := registry.NewAPI(client)
+
+	id := d.KeyColumnQuals["id"].GetStringValue()
+	RegistryRegion := d.KeyColumnQuals["region"].GetStringValue()
+
+	// No inputs
+	if id == "" && RegistryRegion == "" {
+		return nil, nil
+	}
+
+	data, err := registryApi.GetImage(&registry.GetImageRequest{
+		ImageID: id,
+		Region:  parseRegionData,
+	})
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_registry_Image.getRegistryImage", "query_error", err)
+		if is404Error(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/scaleway/table_scaleway_registry_image.go
+++ b/scaleway/table_scaleway_registry_image.go
@@ -125,7 +125,7 @@ func listRegistryImages(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 
 	parseRegionData, err := scw.ParseRegion(region)
 	if err != nil {
-		plugin.Logger(ctx).Error("scaleway_registry_Image.listRegistryImages", "region_parsing_error", err)
+		plugin.Logger(ctx).Error("scaleway_registry_image.listRegistryImages", "region_parsing_error", err)
 		return nil, err
 	}
 
@@ -137,7 +137,7 @@ func listRegistryImages(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	// Create client
 	client, err := getSessionConfig(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("scaleway_registry_Image.listRegistryImages", "connection_error", err)
+		plugin.Logger(ctx).Error("scaleway_registry_image.listRegistryImages", "connection_error", err)
 		return nil, err
 	}
 
@@ -171,7 +171,7 @@ func listRegistryImages(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	for {
 		resp, err := registryApi.ListImages(req)
 		if err != nil {
-			plugin.Logger(ctx).Error("scaleway_registry_Image.listRegistryImages", "query_error", err)
+			plugin.Logger(ctx).Error("scaleway_registry_image.listRegistryImages", "query_error", err)
 			return nil, err
 		}
 
@@ -214,7 +214,7 @@ func getRegistryImage(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	// Create client
 	client, err := getSessionConfig(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("scaleway_registry_Image.getRegistryImage", "connection_error", err)
+		plugin.Logger(ctx).Error("scaleway_registry_image.getRegistryImage", "connection_error", err)
 		return nil, err
 	}
 
@@ -234,7 +234,7 @@ func getRegistryImage(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		Region:  parseRegionData,
 	})
 	if err != nil {
-		plugin.Logger(ctx).Error("scaleway_registry_Image.getRegistryImage", "query_error", err)
+		plugin.Logger(ctx).Error("scaleway_registry_image.getRegistryImage", "query_error", err)
 		if is404Error(err) {
 			return nil, nil
 		}

--- a/scaleway/table_scaleway_registry_image.go
+++ b/scaleway/table_scaleway_registry_image.go
@@ -25,7 +25,8 @@ func tableScalewayRegistryImage(_ context.Context) *plugin.Table {
 				{
 					Name:    "name",
 					Require: plugin.Optional,
-				}, {
+				}, 
+				{
 					Name:    "namespace_id",
 					Require: plugin.Optional,
 				},

--- a/scaleway/table_scaleway_registry_image.go
+++ b/scaleway/table_scaleway_registry_image.go
@@ -38,12 +38,12 @@ func tableScalewayRegistryImage(_ context.Context) *plugin.Table {
 		Columns: []*plugin.Column{
 			{
 				Name:        "name",
-				Description: "The Image name, unique in a namespace",
+				Description: "The image name, unique in a namespace",
 				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "namespace_id",
-				Description: "The unique ID of the Namespace the image belongs to",
+				Description: "The unique ID of the namespace the image belongs to.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("NamespaceID"),
 			},
@@ -70,12 +70,12 @@ func tableScalewayRegistryImage(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "created_at",
-				Description: "The time when the Image was created.",
+				Description: "The time when the image was created.",
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
 			{
 				Name:        "updated_at",
-				Description: "The time when the Image was updated.",
+				Description: "The time when the image was updated.",
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
 			{
@@ -200,7 +200,7 @@ func getRegistryImage(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 	parseRegionData, err := scw.ParseRegion(region)
 	if err != nil {
-		plugin.Logger(ctx).Error("scaleway_registry_Image.getRegistryImage", "region_parsing_error", err)
+		plugin.Logger(ctx).Error("scaleway_registry_image.getRegistryImage", "region_parsing_error", err)
 		return nil, err
 	}
 

--- a/scaleway/table_scaleway_registry_image.go
+++ b/scaleway/table_scaleway_registry_image.go
@@ -57,19 +57,16 @@ func tableScalewayRegistryImage(_ context.Context) *plugin.Table {
 				Name:        "status",
 				Description: "The current status of the Image.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Status").Transform(transform.ToString),
 			},
 			{
 				Name:        "visibility",
 				Description: "A `public` image is pullable from internet without authentication, opposed to a `private` image. `inherit` will use the namespace `is_public` parameter.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Visibility").Transform(transform.ToString),
 			},
 			{
 				Name:        "size",
 				Description: "Image size in bytes, calculated from the size of image layers. One layer used in two tags of the same image is counted once but one layer used in two images is counted twice.",
 				Type:        proto.ColumnType_INT,
-				Transform:   transform.FromField("Size").Transform(transform.ToInt),
 			},
 			{
 				Name:        "created_at",
@@ -205,10 +202,6 @@ func getRegistryImage(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	if err != nil {
 		plugin.Logger(ctx).Error("scaleway_registry_Image.getRegistryImage", "region_parsing_error", err)
 		return nil, err
-	}
-
-	if d.KeyColumnQuals["region"].GetStringValue() != region {
-		return nil, nil
 	}
 
 	// Create client

--- a/scaleway/table_scaleway_registry_image.go
+++ b/scaleway/table_scaleway_registry_image.go
@@ -222,10 +222,10 @@ func getRegistryImage(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	registryApi := registry.NewAPI(client)
 
 	id := d.KeyColumnQuals["id"].GetStringValue()
-	RegistryRegion := d.KeyColumnQuals["region"].GetStringValue()
+	registryRegion := d.KeyColumnQuals["region"].GetStringValue()
 
 	// No inputs
-	if id == "" && RegistryRegion == "" {
+	if id == "" && registryRegion == "" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
# Description
Add table_scaleway_registry_image to scaleway plugin, allowing list and get on registry image.

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  status,
  created_at,
  updated_at
  tags,
  size
from
  scaleway_registry_image;
+--------+--------------------------------------+--------+---------------------------+---------------------------+----------+
| name   | id                                   | status | created_at                | tags                      | size     |
+--------+--------------------------------------+--------+---------------------------+---------------------------+----------+
| test   | 82dba5e9-3ca9-4c2f-b472-966f1a8f4b88 | ready  | 2022-12-09T13:57:04+01:00 | 2022-12-09T13:58:14+01:00 | 31535605 |
| ubuntu | ac4d90fd-e024-43ce-860a-542b1da19040 | ready  | 2022-12-09T13:56:11+01:00 | 2022-12-09T13:56:22+01:00 | 31535605 |
+--------+--------------------------------------+--------+---------------------------+---------------------------+----------+
```
</details>
