### PR TITLE
feat(golang): add tables kubernetes cluster/pool/node

### DIFF
--- a/docs/tables/scaleway_kubernetes_cluster.md
+++ b/docs/tables/scaleway_kubernetes_cluster.md
@@ -1,6 +1,6 @@
 # Table: scaleway_kubernetes_cluster
 
-A Scaleway Kubernetes is a public cloud mamanged kubernetes available in Scaleway.
+A Scaleway Kubernetes is a public cloud managed kubernetes available in Scaleway.
 
 ## Examples
 

--- a/docs/tables/scaleway_kubernetes_cluster.md
+++ b/docs/tables/scaleway_kubernetes_cluster.md
@@ -68,7 +68,7 @@ where
 
 ```
 
-### List clusters with upgrade available
+### List clusters with upgrades available
 
 ```sql
 select

--- a/docs/tables/scaleway_kubernetes_cluster.md
+++ b/docs/tables/scaleway_kubernetes_cluster.md
@@ -19,7 +19,7 @@ from
   scaleway_kubernetes_cluster;
 ```
 
-### List Kapsule cluster
+### List Kapsule clusters
 
 ```sql
 select

--- a/docs/tables/scaleway_kubernetes_cluster.md
+++ b/docs/tables/scaleway_kubernetes_cluster.md
@@ -65,7 +65,6 @@ from
   scaleway_kubernetes_cluster
 where
   version < '1.24';
-
 ```
 
 ### List clusters with upgrades available
@@ -82,7 +81,6 @@ from
   scaleway_kubernetes_cluster
 where
   upgrade_available is true;
-
 ```
 
 ### List clusters with auto-upgrade enabled
@@ -99,5 +97,4 @@ from
   scaleway_kubernetes_cluster
 where
   auto_upgrade @> '{"enabled":true}';
-
 ```

--- a/docs/tables/scaleway_kubernetes_cluster.md
+++ b/docs/tables/scaleway_kubernetes_cluster.md
@@ -51,7 +51,7 @@ where
   type = 'multicloud';
 ```
 
-### List clusters with Kubernetes version is inferior to 1.24
+### List clusters with Kubernetes version inferior to 1.24
 
 ```sql
 select

--- a/docs/tables/scaleway_kubernetes_cluster.md
+++ b/docs/tables/scaleway_kubernetes_cluster.md
@@ -1,0 +1,103 @@
+# Table: scaleway_kubernetes_cluster
+
+A Scaleway Kubernetes is a public cloud mamanged kubernetes available in Scaleway.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  description,
+  type,
+  cluster_url,
+  id,
+  status,
+  version
+from
+  scaleway_kubernetes_cluster;
+```
+
+### List Kapsule cluster
+
+```sql
+select
+  name,
+  description,
+  type,
+  cluster_url,
+  id,
+  status
+from
+  scaleway_kubernetes_cluster
+where
+  type = 'kapsule';
+```
+
+### List Kosmos cluster
+
+```sql
+select
+  name,
+  description,
+  type,
+  cluster_url,
+  id,
+  status
+from
+  scaleway_kubernetes_cluster
+where
+  type = 'multicloud';
+```
+
+### List clusters with Kubernetes version is inferior to 1.24
+
+```sql
+select
+  name,
+  description,
+  type,
+  cluster_url,
+  id,
+  status
+from
+  scaleway_kubernetes_cluster
+where
+  version < '1.24';
+
+```
+
+### List clusters with upgrade available
+
+```sql
+select
+  name,
+  type,
+  id,
+  version,
+  auto_upgrade,
+  upgrade_available
+from
+  scaleway_kubernetes_cluster
+where
+  upgrade_available is true;
+
+```
+
+### List clusters with auto upgrade enable
+
+```sql
+select
+  name,
+  type,
+  id,
+  version,
+  auto_upgrade,
+  upgrade_available
+from
+  scaleway_kubernetes_cluster
+where
+  auto_upgrade @> '{"enabled":true}';
+
+```

--- a/docs/tables/scaleway_kubernetes_cluster.md
+++ b/docs/tables/scaleway_kubernetes_cluster.md
@@ -85,7 +85,7 @@ where
 
 ```
 
-### List clusters with auto upgrade enable
+### List clusters with auto-upgrade enabled
 
 ```sql
 select

--- a/docs/tables/scaleway_kubernetes_node.md
+++ b/docs/tables/scaleway_kubernetes_node.md
@@ -1,6 +1,6 @@
 # Table: scaleway_kubernetes_pool
 
-A Scaleway Kubernetes is a public cloud mamanged kubernetes available in Scaleway.
+A Scaleway Kubernetes is a public cloud managed kubernetes available in Scaleway.
 
 ## Examples
 

--- a/docs/tables/scaleway_kubernetes_node.md
+++ b/docs/tables/scaleway_kubernetes_node.md
@@ -1,4 +1,4 @@
-# Table: scaleway_kubernetes_pool
+# Table: scaleway_kubernetes_node
 
 A Scaleway Kubernetes is a public cloud managed kubernetes available in Scaleway.
 

--- a/docs/tables/scaleway_kubernetes_node.md
+++ b/docs/tables/scaleway_kubernetes_node.md
@@ -1,6 +1,6 @@
 # Table: scaleway_kubernetes_node
 
-A Scaleway Kubernetes is a public cloud managed kubernetes available in Scaleway.
+A Scaleway Kubernetes node may be a virtual or physical machine, depending on the cluster. Each node is managed by the control plane and contains the services necessary to run Pods.
 
 ## Examples
 

--- a/docs/tables/scaleway_kubernetes_node.md
+++ b/docs/tables/scaleway_kubernetes_node.md
@@ -49,7 +49,7 @@ where
   public_ip_v6 != '<nil>';
 ```
 
-### List kubernetes node createad more than 90 days ago
+### List kubernetes nodes created more than 90 days ago
 
 ```sql
 select

--- a/docs/tables/scaleway_kubernetes_node.md
+++ b/docs/tables/scaleway_kubernetes_node.md
@@ -33,7 +33,7 @@ where
   status <> 'ready';
 ```
 
-### List kubernetes node with ipv6 public
+### List kubernetes nodes with ipv6 public
 
 ```sql
 select

--- a/docs/tables/scaleway_kubernetes_node.md
+++ b/docs/tables/scaleway_kubernetes_node.md
@@ -17,7 +17,7 @@ from
   scaleway_kubernetes_node;
 ```
 
-### List kubernetes node with status is not ready
+### List kubernetes nodes where status is not ready
 
 ```sql
 select

--- a/docs/tables/scaleway_kubernetes_pool.md
+++ b/docs/tables/scaleway_kubernetes_pool.md
@@ -67,5 +67,4 @@ from
   scaleway_kubernetes_pool
 where
   version < '1.24';
-
 ```

--- a/docs/tables/scaleway_kubernetes_pool.md
+++ b/docs/tables/scaleway_kubernetes_pool.md
@@ -1,6 +1,6 @@
 # Table: scaleway_kubernetes_pool
 
-A Scaleway Kubernetes is a public cloud mamanged kubernetes available in Scaleway.
+A Scaleway Kubernetes pool is a group of Scaleway Instances, organized by type. It represents the computing power of the cluster and contains the Kubernetes nodes, on which the containers run.
 
 ## Examples
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.40.58
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.10
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.12
 	github.com/turbot/go-kit v0.4.0
 	github.com/turbot/steampipe-plugin-sdk/v4 v4.1.11
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.10 h1:wsfMs0iv+MJiViM37qh5VEKISi3/ZUq2nNKNdqmumAs=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.10/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.12 h1:Aaz4T7dZp7cB2cv7D/tGtRdSMh48sRaDYr7Jh0HV4qQ=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.12/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sethvargo/go-retry v0.1.0 h1:8sPqlWannzcReEcYjHSNw9becsiYudcwTD7CasGjQaI=
 github.com/sethvargo/go-retry v0.1.0/go.mod h1:JzIOdZqQDNpPkQDmcqgtteAcxFLtYpNF/zJCM1ysDg8=

--- a/scaleway/plugin.go
+++ b/scaleway/plugin.go
@@ -27,6 +27,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"scaleway_instance_server":         tableScalewayInstanceServer(ctx),
 			"scaleway_instance_snapshot":       tableScalewayInstanceSnapshot(ctx),
 			"scaleway_instance_volume":         tableScalewayInstanceVolume(ctx),
+			"scaleway_kubernetes_cluster":      tableScalewayKubernetesCluster(ctx),
 			"scaleway_object_bucket":           tableScalewayObjectBucket(ctx),
 			"scaleway_rdb_database":            tableScalewayRDBDatabase(ctx),
 			"scaleway_rdb_instance":            tableScalewayRDBInstance(ctx),

--- a/scaleway/table_scaleway_kubernetes_cluster.go
+++ b/scaleway/table_scaleway_kubernetes_cluster.go
@@ -283,10 +283,9 @@ func getKubernetesCluster(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	kubernetesApi := k8s.NewAPI(client)
 
 	id := d.KeyColumnQuals["id"].GetStringValue()
-	KubernetesRegion := d.KeyColumnQuals["region"].GetStringValue()
 
-	// No inputs
-	if id == "" && KubernetesRegion == "" {
+	// No input id has been passed
+	if id == "" {
 		return nil, nil
 	}
 

--- a/scaleway/table_scaleway_kubernetes_cluster.go
+++ b/scaleway/table_scaleway_kubernetes_cluster.go
@@ -1,0 +1,306 @@
+package scaleway
+
+import (
+	"context"
+
+	"github.com/scaleway/scaleway-sdk-go/api/k8s/v1"
+
+	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableScalewayKubernetesCluster(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:              "scaleway_kubernetes_cluster",
+		Description:       "Kubernetes Clusters allow you to manage your Container Kubernetes in Scaleway.",
+		GetMatrixItemFunc: BuildRegionList,
+		List: &plugin.ListConfig{
+			Hydrate: listKubernetesClusters,
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "name",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "region",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		Get: &plugin.GetConfig{
+			Hydrate:    getKubernetesCluster,
+			KeyColumns: plugin.AllColumns([]string{"id", "region"}),
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "name",
+				Description: "The user-defined name of the cluster.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "description",
+				Description: "A description of the cluster.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "status",
+				Description: "The current status of the cluster.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Status").Transform(transform.ToString),
+			},
+			{
+				Name:        "type",
+				Description: "The type of the cluster.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Type").Transform(transform.ToString),
+			},
+			{
+				Name:        "version",
+				Description: "The Kubernetes version of the cluster.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "cni",
+				Description: "The cluster visibility policy.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Cni"),
+			},
+			{
+				Name:        "cluster_url",
+				Description: "The Kubernetes API server URL of the cluster.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ClusterURL"),
+			},
+			{
+				Name:        "dns_wildcard",
+				Description: "The DNS wildcard resovling all the ready nodes of the cluster.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DNSWildcard"),
+			},
+			{
+				Name:        "created_at",
+				Description: "The time when the cluster was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "updated_at",
+				Description: "The time when the cluster was updated.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "autoscaler_config",
+				Description: "The autoscaler config for the cluster.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("AutoscalerConfig"),
+			},
+			{
+				Name:        "dashboard_enabled",
+				Description: "The enablement of the Kubernetes Dashboard in the cluster.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromField("DashboardEnabled").Transform(transform.ToBool),
+			},
+			{
+				Name:        "auto_upgrade",
+				Description: "The auto upgrade configuration of the cluster.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("AutoUpgrade"),
+			},
+			{
+				Name:        "upgrade_available",
+				Description: "True if a new Kubernetes version is available.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "feature_gates",
+				Description: "The list of enabled feature gates.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("FeatureGates").Transform(transform.ToString),
+			},
+			{
+				Name:        "admission_plugins",
+				Description: "The list of enabled admission plugins.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("AdmissionPlugins").Transform(transform.ToString),
+			},
+			{
+				Name:        "open_id_connect_config",
+				Description: "The OpenID Connect configuration of the cluster.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("OpenIDConnectConfig"),
+			},
+			{
+				Name:        "apiserver_cert_sans",
+				Description: "The additional Subject Alternative Names for the Kubernetes API server certificate.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ApiserverCertSans").Transform(transform.ToString),
+			},
+
+			// Scaleway standard columns
+			{
+				Name:        "project",
+				Description: "The ID of the project where the cluster resides.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "organization",
+				Description: "The ID of the organization where the cluster resides.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "region",
+				Description: "Specifies the region where the cluster is located.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Region").Transform(transform.ToString),
+			},
+			{
+				Name:        "id",
+				Description: "A unique identifier of the instance.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ID"),
+			},
+			{
+				Name:        "tags",
+				Description: "A list of tags associated with the cluster.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromValue(),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: "Title of the resource.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listKubernetesClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	region := plugin.GetMatrixItem(ctx)["region"].(string)
+
+	parseRegionData, err := scw.ParseRegion(region)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_kubernetes_cluster.listKubernetesClusters", "region_parsing_error", err)
+		return nil, err
+	}
+
+	quals := d.KeyColumnQuals
+	if quals["region"] != nil && quals["region"].GetStringValue() != region {
+		return nil, nil
+	}
+
+	// Create client
+	client, err := getSessionConfig(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_kubernetes_cluster.listKubernetesClusters", "connection_error", err)
+		return nil, err
+	}
+
+	// Create SDK objects for Scaleway Kubernetes product
+	kubernetesApi := k8s.NewAPI(client)
+
+	req := &k8s.ListClustersRequest{
+		Region: parseRegionData,
+		Page:   scw.Int32Ptr(1),
+	}
+	// Additional filters
+	if quals["name"] != nil {
+		req.Name = scw.StringPtr(quals["name"].GetStringValue())
+	}
+
+	// Retrieve the list of clusters
+	maxResult := int64(100)
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < maxResult {
+			maxResult = *limit
+		}
+	}
+	req.PageSize = scw.Uint32Ptr(uint32(maxResult))
+
+	var count int
+
+	for {
+		resp, err := kubernetesApi.ListClusters(req)
+		if err != nil {
+			plugin.Logger(ctx).Error("scaleway_kubernetes_cluster.listKubernetesClusters", "query_error", err)
+			return nil, err
+		}
+
+		for _, cluster := range resp.Clusters {
+			d.StreamListItem(ctx, cluster)
+
+			// Increase the resource count by 1
+			count++
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+
+		if resp.TotalCount == uint32(count) {
+			break
+		}
+		req.Page = scw.Int32Ptr(*req.Page + 1)
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getKubernetesCluster(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	region := plugin.GetMatrixItem(ctx)["region"].(string)
+
+	parseRegionData, err := scw.ParseRegion(region)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_kubernetes_cluster.getKubernetesCluster", "region_parsing_error", err)
+		return nil, err
+	}
+
+	if d.KeyColumnQuals["region"].GetStringValue() != region {
+		return nil, nil
+	}
+
+	// Create client
+	client, err := getSessionConfig(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_kubernetes_cluster.getKubernetesCluster", "connection_error", err)
+		return nil, err
+	}
+
+	// Create SDK objects for Scaleway Kubernetes product
+	kubernetesApi := k8s.NewAPI(client)
+
+	id := d.KeyColumnQuals["id"].GetStringValue()
+	KubernetesRegion := d.KeyColumnQuals["region"].GetStringValue()
+
+	// No inputs
+	if id == "" && KubernetesRegion == "" {
+		return nil, nil
+	}
+
+	data, err := kubernetesApi.GetCluster(&k8s.GetClusterRequest{
+		ClusterID: id,
+		Region:    parseRegionData,
+	})
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_kubernetes_cluster.getKubernetesCluster", "query_error", err)
+		if is404Error(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/scaleway/table_scaleway_kubernetes_node.go
+++ b/scaleway/table_scaleway_kubernetes_node.go
@@ -79,7 +79,7 @@ func tableScalewayKubernetesNode(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "conditions",
-				Description: "These conditions contains the Node Problem Detector conditionse.",
+				Description: "These conditions contain the Node Problem Detector condition.",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("Conditions"),
 			},

--- a/scaleway/table_scaleway_kubernetes_node.go
+++ b/scaleway/table_scaleway_kubernetes_node.go
@@ -254,10 +254,9 @@ func getKubernetesNode(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	kubernetesApi := k8s.NewAPI(client)
 
 	id := d.KeyColumnQuals["id"].GetStringValue()
-	KubernetesRegion := d.KeyColumnQuals["region"].GetStringValue()
 
 	// No inputs
-	if id == "" && KubernetesRegion == "" {
+	if id == "" {
 		return nil, nil
 	}
 

--- a/scaleway/table_scaleway_kubernetes_pool.go
+++ b/scaleway/table_scaleway_kubernetes_pool.go
@@ -283,10 +283,9 @@ func getKubernetesPool(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	kubernetesApi := k8s.NewAPI(client)
 
 	id := d.KeyColumnQuals["id"].GetStringValue()
-	KubernetesRegion := d.KeyColumnQuals["region"].GetStringValue()
 
 	// No inputs
-	if id == "" && KubernetesRegion == "" {
+	if id == "" {
 		return nil, nil
 	}
 

--- a/scaleway/table_scaleway_kubernetes_pool.go
+++ b/scaleway/table_scaleway_kubernetes_pool.go
@@ -55,7 +55,7 @@ func tableScalewayKubernetesPool(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "node_type",
-				Description: "The type of the pool.",
+				Description: "The type of the node.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("NodeType").Transform(transform.ToString),
 			},


### PR DESCRIPTION
# Describe

Add tables in scaleway plugin to list kubernetes cluster, kubernetes node and kubernetes pool. 

# Example query results
<details>
  <summary>Results kubernetes cluster</summary>
  
```
> select
  name,
  type,
  id,
  version,
  auto_upgrade,
  upgrade_available
from
  scaleway_kubernetes_cluster
where
  auto_upgrade @> '{"enabled":false}';
+---------------------+------------+--------------------------------------+---------+---------------------------------------------------------------------+-------------------+
| name                | type       | id                                   | version | auto_upgrade                                                        | upgrade_available |
+---------------------+------------+--------------------------------------+---------+---------------------------------------------------------------------+-------------------+
| k8s-nervous-wescoff | kapsule    | 9f4b96db-a65a-4978-8e80-fac94adac369 | 1.24.7  | {"enabled":false,"maintenance_window":{"day":"any","start_hour":0}} | false             |
| k8s-jovial-kepler   | multicloud | 0f708873-0f49-4c44-89a3-6d1d6e4ff568 | 1.23.13 | {"enabled":false,"maintenance_window":{"day":"any","start_hour":0}} | true              |
+---------------------+------------+--------------------------------------+---------+---------------------------------------------------------------------+-------------------+
> 
```
</details>


<details>
  <summary>Results kubernetes node</summary>
  
```
> select
  name,
  cluster_id,
  id,
  status,
  updated_at,
  created_at
from
  scaleway_kubernetes_node
where
  created_at >= now() - interval '90' day
+------------------------------------------------+--------------------------------------+--------------------------------------+--------+---------------------------+---------------------------+
| name                                           | cluster_id                           | id                                   | status | updated_at                | created_at                |
+------------------------------------------------+--------------------------------------+--------------------------------------+--------+---------------------------+---------------------------+
| scw-k8s-cranky-hofstadter-default-b59b27b905a2 | 5d3d4ca1-7a0f-4651-8779-29d59fae42aa | b59b27b9-05a2-442a-a806-26549a14311e | ready  | 2023-02-02T09:51:26+01:00 | 2023-02-02T08:47:31+01:00 |
+------------------------------------------------+--------------------------------------+--------------------------------------+--------+---------------------------+---------------------------+
```
</details>


<details>
  <summary>Results kubernetes pool</summary>
  
```
> select
  name,
  node_type,
  cluster_id,
  id,
  status,
  version
from
  scaleway_kubernetes_pool
where
  version < '1.24';

+---------+------------+--------------------------------------+--------------------------------------+--------+---------+
| name    | node_type  | cluster_id                           | id                                   | status | version |
+---------+------------+--------------------------------------+--------------------------------------+--------+---------+
| default | play2_nano | 5d3d4ca1-7a0f-4651-8779-29d59fae42aa | 6b1c2326-62ad-4f15-9484-8a123d9ac1fd | ready  | 1.23.13 |
+---------+------------+--------------------------------------+--------------------------------------+--------+---------+
```
</details>
