### PR TITLE
add Invoices table

### DIFF
--- a/docs/tables/scaleway_invoices.md
+++ b/docs/tables/scaleway_invoices.md
@@ -1,0 +1,132 @@
+---
+title: "Steampipe Table: scaleway_invoice - Query Scaleway Invoices using SQL"
+description: "Allows users to query Scaleway Invoices, providing detailed information about billing and usage for Scaleway services."
+---
+
+# Table: scaleway_invoice - Query Scaleway Invoices using SQL
+
+Scaleway Invoices are detailed records of charges for the use of Scaleway's cloud services. These invoices provide a comprehensive breakdown of costs associated with various resources and services used within a Scaleway account.
+
+## Table Usage Guide
+
+The `scaleway_invoice` table provides insights into billing information within Scaleway. As a finance manager or cloud administrator, explore invoice-specific details through this table, including total amounts, billing periods, and associated organizations. Utilize it to track expenses, verify charges, and manage cloud spending across different projects and timeframes.
+
+## Examples
+
+### Basic info
+Explore the basic details of your Scaleway invoices, including their unique identifiers, associated organizations, and billing periods. This can help in tracking and managing your cloud expenses effectively.
+
+```sql
+SELECT
+  id,
+  organization_id,
+  billing_period,
+  total_taxed_amount,
+  state,
+  currency
+FROM
+  scaleway_invoices;
+```
+
+### Get total billed amount for each organization
+Calculate the total amount billed to each organization. This provides an overview of cloud spending across different entities within your Scaleway account.
+
+```sql
+SELECT
+  organization_id,
+  SUM(total_taxed_amount) as total_billed,
+  currency
+FROM
+  scaleway_invoices
+GROUP BY
+  organization_id,
+  currency;
+```
+
+### Find invoices with high discount amounts
+Identify invoices with significant discounts. This can help in understanding which billing periods or services are providing the most cost savings.
+
+```sql
+SELECT
+  id,
+  billing_period,
+  total_discount_amount,
+  total_taxed_amount,
+  currency
+FROM
+  scaleway_invoices
+WHERE
+  total_discount_amount > 1000
+ORDER BY
+  total_discount_amount DESC;
+```
+
+### List invoices for a specific date range
+Retrieve invoices within a specific time frame. This is useful for periodic financial reviews or audits.
+
+```sql
+SELECT
+  id,
+  billing_period,
+  total_taxed_amount,
+  issued_date,
+  currency
+FROM
+  scaleway_invoices
+WHERE
+  issued_date BETWEEN '2023-01-01' AND '2023-12-31'
+ORDER BY
+  issued_date;
+```
+
+### Get the average invoice amount by month
+Calculate the average invoice amount for each month. This helps in understanding monthly spending patterns and budgeting for cloud services.
+
+```sql
+SELECT
+  DATE_TRUNC('month', issued_date) AS month,
+  AVG(total_taxed_amount) AS average_invoice_amount,
+  currency
+FROM
+  scaleway_invoices
+GROUP BY
+  DATE_TRUNC('month', issued_date),
+  currency
+ORDER BY
+  month;
+```
+
+### Compare total taxed and untaxed amounts
+Analyze the difference between taxed and untaxed amounts for each invoice to understand the tax impact on your cloud spending.
+
+```sql
+SELECT
+  id,
+  total_untaxed_amount,
+  total_taxed_amount,
+  total_taxed_amount - total_untaxed_amount AS tax_amount,
+  currency
+FROM
+  scaleway_invoices
+ORDER BY
+  tax_amount DESC;
+```
+
+### Examine discounts and their impact
+Investigate how discounts affect your invoices by comparing the undiscounted amount to the final taxed amount.
+
+```sql
+SELECT
+  id,
+  total_undiscount_amount,
+  total_discount_amount,
+  total_taxed_amount,
+  total_discount_amount / total_undiscount_amount * 100 AS discount_percentage,
+  currency
+FROM
+  scaleway_invoices
+WHERE
+  total_discount_amount > 0
+ORDER BY
+  discount_percentage DESC;
+```

--- a/scaleway/plugin.go
+++ b/scaleway/plugin.go
@@ -31,6 +31,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"scaleway_instance_server":         tableScalewayInstanceServer(ctx),
 			"scaleway_instance_snapshot":       tableScalewayInstanceSnapshot(ctx),
 			"scaleway_instance_volume":         tableScalewayInstanceVolume(ctx),
+			"scaleway_invoices":                tableScalewayInvoices(ctx),
 			"scaleway_kubernetes_cluster":      tableScalewayKubernetesCluster(ctx),
 			"scaleway_kubernetes_node":         tableScalewayKubernetesNode(ctx),
 			"scaleway_kubernetes_pool":         tableScalewayKubernetesPool(ctx),

--- a/scaleway/table_scaleway_invoices.go
+++ b/scaleway/table_scaleway_invoices.go
@@ -1,0 +1,259 @@
+package scaleway
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	billing "github.com/scaleway/scaleway-sdk-go/api/billing/v2beta1"
+
+	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+func tableScalewayInvoices(ctx context.Context) *plugin.Table {
+	plugin.Logger(ctx).Debug("Initializing Scaleway invoices table")
+	return &plugin.Table{
+		Name:        "scaleway_invoices",
+		Description: "invoices in your Scaleway account.",
+		List: &plugin.ListConfig{
+			Hydrate: listScalewayInvoices,
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "organization_id", Require: plugin.Optional},
+			},
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "id",
+				Type:        proto.ColumnType_STRING,
+				Description: "The unique identifier of the invoices.",
+				Transform:   transform.FromField("ID"),
+			},
+			{
+				Name:        "organization_id",
+				Type:        proto.ColumnType_STRING,
+				Description: "The organization ID associated with the invoices.",
+				Transform:   transform.FromField("OrganizationID"),
+			},
+			{
+				Name:        "organization_name",
+				Type:        proto.ColumnType_STRING,
+				Description: "The organization name associated with the invoices.",
+			},
+			{
+				Name:        "start_date",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Description: "The start date of the billing period.",
+			},
+			{
+				Name:        "stop_date",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Description: "The end date of the billing period.",
+			},
+			{
+				Name:        "billing_period",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Description: "The billing period for the invoices.",
+			},
+			{
+				Name:        "issued_date",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Description: "The date when the invoices was issued.",
+			},
+			{
+				Name:        "due_date",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Description: "The due date for the invoices payment.",
+			},
+			{
+				Name:        "total_untaxed_amount",
+				Type:        proto.ColumnType_DOUBLE,
+				Description: "The total untaxed amount of the invoices.",
+				Transform:   transform.FromField("TotalUntaxed").Transform(extractAmount),
+			},
+			{
+				Name:        "total_taxed_amount",
+				Type:        proto.ColumnType_DOUBLE,
+				Description: "The total taxed amount of the invoices.",
+				Transform:   transform.FromField("TotalTaxed").Transform(extractAmount),
+			},
+			{
+				Name:        "total_discount_amount",
+				Type:        proto.ColumnType_DOUBLE,
+				Description: "The total discount amount of the invoice (always positive).",
+				Transform:   transform.FromField("TotalDiscount").Transform(extractAmount),
+			},
+			{
+				Name:        "total_undiscount_amount",
+				Type:        proto.ColumnType_DOUBLE,
+				Description: "The total undiscounted amount of the invoices.",
+				Transform:   transform.FromField("TotalUndiscount").Transform(extractAmount),
+			},
+			{
+				Name:        "currency",
+				Type:        proto.ColumnType_STRING,
+				Description: "The currency used for all monetary values in the invoices.",
+				Transform:   transform.FromField("TotalTaxed").Transform(extractCurrency),
+			},
+			{
+				Name:        "type",
+				Type:        proto.ColumnType_STRING,
+				Description: "The type of the invoices.",
+			},
+			{
+				Name:        "state",
+				Type:        proto.ColumnType_STRING,
+				Description: "The current state of the invoices.",
+			},
+			{
+				Name:        "number",
+				Type:        proto.ColumnType_INT,
+				Description: "The invoices number.",
+			},
+			{
+				Name:        "seller_name",
+				Type:        proto.ColumnType_STRING,
+				Description: "The name of the seller.",
+			},
+		},
+	}
+}
+
+func extractAmount(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Debug("extractAmount", "field", d.ColumnName, "raw_value", d.Value)
+
+	if d.Value == nil {
+		plugin.Logger(ctx).Warn("extractAmount: nil value", "field", d.ColumnName)
+		return nil, nil
+	}
+
+	money, ok := d.Value.(*scw.Money)
+	if !ok || money == nil {
+		plugin.Logger(ctx).Warn("extractAmount: unexpected type or nil", "type", fmt.Sprintf("%T", d.Value))
+		return nil, nil
+	}
+
+	amount := float64(money.Units) + float64(money.Nanos)/1e9
+	if d.ColumnName == "total_discount_amount" {
+		return math.Abs(amount), nil
+	}
+	return amount, nil
+}
+
+func extractCurrency(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Debug("extractCurrency", "field", d.ColumnName, "raw_value", d.Value)
+
+	if d.Value == nil {
+		plugin.Logger(ctx).Warn("extractCurrency: nil value", "field", d.ColumnName)
+		return nil, nil
+	}
+
+	switch v := d.Value.(type) {
+	case *scw.Money:
+		if v == nil {
+			return nil, nil
+		}
+		return v.CurrencyCode, nil
+	default:
+		plugin.Logger(ctx).Warn("extractCurrency: unexpected type", "type", fmt.Sprintf("%T", d.Value))
+		return nil, nil
+	}
+}
+
+type invoicesItem struct {
+	ID               string              `json:"id"`
+	OrganizationID   string              `json:"organization_id"`
+	OrganizationName string              `json:"organization_name"`
+	StartDate        *time.Time          `json:"start_date"`
+	StopDate         *time.Time          `json:"stop_date"`
+	IssuedDate       *time.Time          `json:"issued_date"`
+	DueDate          *time.Time          `json:"due_date"`
+	TotalUntaxed     *scw.Money          `json:"total_untaxed"`
+	TotalTaxed       *scw.Money          `json:"total_taxed"`
+	TotalDiscount    *scw.Money          `json:"total_discount"`
+	TotalUndiscount  *scw.Money          `json:"total_undiscount"`
+	TotalTax         *scw.Money          `json:"total_tax"`
+	Type             billing.InvoiceType `json:"type"`
+	Number           int32               `json:"number"`
+	State            string              `json:"state"`
+	BillingPeriod    *time.Time          `json:"billing_period"`
+	SellerName       string              `json:"seller_name"`
+}
+
+func listScalewayInvoices(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	// Get client configuration
+	client, err := getSessionConfig(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_invoices.listScalewayInvoices", "connection_error", err)
+		return nil, err
+	}
+
+	// Check if the client is properly configured
+	if client == nil {
+		return nil, fmt.Errorf("scaleway client is not properly configured")
+	}
+
+	billingAPI := billing.NewAPI(client)
+
+	// Prepare the request
+	req := &billing.ListInvoicesRequest{}
+
+	// Get the organization_id from the config
+	scalewayConfig := GetConfig(d.Connection)
+	var organizationID string
+	if scalewayConfig.OrganizationID != nil {
+		organizationID = *scalewayConfig.OrganizationID
+	}
+
+	// Check if organization_id is specified in the query
+	if d.EqualsQualString("organization_id") != "" {
+		organizationID = d.EqualsQualString("organization_id")
+	}
+
+	// Log a warning if organization_id is not provided by either config or query
+	if organizationID == "" {
+		plugin.Logger(ctx).Warn("scaleway_invoices.listScalewayInvoices", "warning", "No organization_id provided in config or query")
+	}
+
+	// Set the organization_id in the request if it's available
+	if organizationID != "" {
+		req.OrganizationID = &organizationID
+	}
+
+	// Make the API request to list invoices
+	resp, err := billingAPI.ListInvoices(req)
+	if err != nil {
+		plugin.Logger(ctx).Error("scaleway_invoices.listScalewayInvoices", "api_error", err)
+		return nil, err
+	}
+
+	for _, invoices := range resp.Invoices {
+		plugin.Logger(ctx).Debug("raw invoices data", "invoices", fmt.Sprintf("%+v", invoices))
+
+		item := invoicesItem{
+			ID:               invoices.ID,
+			OrganizationID:   invoices.OrganizationID,
+			OrganizationName: invoices.OrganizationName,
+			StartDate:        invoices.StartDate,
+			StopDate:         invoices.StopDate,
+			IssuedDate:       invoices.IssuedDate,
+			DueDate:          invoices.DueDate,
+			TotalUntaxed:     invoices.TotalUntaxed,
+			TotalTaxed:       invoices.TotalTaxed,
+			TotalDiscount:    invoices.TotalDiscount,
+			TotalUndiscount:  invoices.TotalUndiscount,
+			TotalTax:         invoices.TotalTax,
+			Type:             invoices.Type,
+			Number:           invoices.Number,
+			State:            invoices.State,
+			BillingPeriod:    invoices.BillingPeriod,
+			SellerName:       invoices.SellerName,
+		}
+		d.StreamListItem(ctx, item)
+	}
+
+	return nil, nil
+}


### PR DESCRIPTION
I've added support for a new table named invoices. This table recover the data form : https://www.scaleway.com/en/developers/api/billing/#path-invoices-list-invoices using scaleway-sdk-go/api/billing

I'm not a go developer, so I've intensively used AI to generate the table code. I've tried my best to conform to coding convention and styling of the project.

The table have been extensively tested, and the documentation reflects that.

I humbly hope this contribution is decent enough to be integrated.
