### PR TITLE
Fixed typo doc for the table scaleway_billing_invoice

### DIFF
--- a/docs/tables/scaleway_billing_invoice.md
+++ b/docs/tables/scaleway_billing_invoice.md
@@ -1,6 +1,6 @@
 ---
-title: Steampipe Table: scaleway_billing_invoice - Query Scaleway Invoices using SQL  
-description: Enables users to query Scaleway invoices, offering comprehensive billing and usage details for Scaleway cloud services.
+title: "Steampipe Table: scaleway_billing_invoice - Query Scaleway Invoices using SQL"
+description: "Enables users to query Scaleway invoices, offering comprehensive billing and usage details for Scaleway cloud services."
 ---
 
 # Table: scaleway_billing_invoice - Query Scaleway invoices using SQL


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
