### PR TITLE
Migrate plugin to steampipe-plugin-sdk v6.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.183
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.22.0.20240118144829-99a99cc1d1cc
 	github.com/turbot/go-kit v1.1.0
-	github.com/turbot/steampipe-plugin-sdk/v5 v5.14.0
+	github.com/turbot/steampipe-plugin-sdk/v6 v6.0.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/aws/aws-sdk-go v1.44.183
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.22.0.20240118144829-99a99cc1d1cc
-	github.com/turbot/go-kit v1.1.0
+	github.com/turbot/go-kit v1.3.1
 	github.com/turbot/steampipe-plugin-sdk/v6 v6.0.0
 )
 
@@ -31,7 +31,7 @@ require (
 	github.com/eko/gocache/store/ristretto/v4 v4.2.1 // indirect
 	github.com/fatih/color v1.17.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gertd/go-pluralize v0.2.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
@@ -74,7 +74,7 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sethvargo/go-retry v0.2.4 // indirect
 	github.com/stevenle/topsort v0.2.0 // indirect
-	github.com/tkrajina/go-reflector v0.5.6 // indirect
+	github.com/tkrajina/go-reflector v0.5.8 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/zclconf/go-cty v1.14.4 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -718,8 +718,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
-github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gertd/go-pluralize v0.2.1 h1:M3uASbVjMnTsPb0PNqg+E/24Vwigyo/tvyMTtAlLgiA=
 github.com/gertd/go-pluralize v0.2.1/go.mod h1:rbYaKDbsXxmRfr8uygAEKhOWsjyrrqrkHVpZvoOp8zk=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -1056,10 +1056,10 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tkrajina/go-reflector v0.5.6 h1:hKQ0gyocG7vgMD2M3dRlYN6WBBOmdoOzJ6njQSepKdE=
-github.com/tkrajina/go-reflector v0.5.6/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
-github.com/turbot/go-kit v1.1.0 h1:2gW+MFDJD+mN41GcvhAajTrwR8HgN9KKJ8HnYwPGTV0=
-github.com/turbot/go-kit v1.1.0/go.mod h1:1xmRuQ0cn/10QUMNLNOAFIqN8P6Rz5s3VLT8mkN3nF8=
+github.com/tkrajina/go-reflector v0.5.8 h1:yPADHrwmUbMq4RGEyaOUpz2H90sRsETNVpjzo3DLVQQ=
+github.com/tkrajina/go-reflector v0.5.8/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
+github.com/turbot/go-kit v1.3.1 h1:RGyqY9E57L0HVBLJ64ArzcIy/8jC8YaK9da+VMtoq3o=
+github.com/turbot/go-kit v1.3.1/go.mod h1:hW2nItIxNEYRQbwqsMKmEfyKiuvKZPnjuYso65b8DL4=
 github.com/turbot/steampipe-plugin-sdk/v6 v6.0.0 h1:Zm0UA4JJ20X8qoDLSgRSMKrfBvNdqJcJ47A6HOX7G2o=
 github.com/turbot/steampipe-plugin-sdk/v6 v6.0.0/go.mod h1:CIMDhrEuWC9+x+y1fOBdWnCHFCDHKBfob7aNOlNoJbY=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/go.sum
+++ b/go.sum
@@ -1060,8 +1060,8 @@ github.com/tkrajina/go-reflector v0.5.6 h1:hKQ0gyocG7vgMD2M3dRlYN6WBBOmdoOzJ6njQ
 github.com/tkrajina/go-reflector v0.5.6/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/turbot/go-kit v1.1.0 h1:2gW+MFDJD+mN41GcvhAajTrwR8HgN9KKJ8HnYwPGTV0=
 github.com/turbot/go-kit v1.1.0/go.mod h1:1xmRuQ0cn/10QUMNLNOAFIqN8P6Rz5s3VLT8mkN3nF8=
-github.com/turbot/steampipe-plugin-sdk/v5 v5.14.0 h1:CyufzeM2BMbA2nJRuujucchp9NZ6BEeYA2phhdMXsW4=
-github.com/turbot/steampipe-plugin-sdk/v5 v5.14.0/go.mod h1:VHKUVPx29JEHXjuY9Kj/fdabceHdGQB1kaH4Dik/XY8=
+github.com/turbot/steampipe-plugin-sdk/v6 v6.0.0 h1:Zm0UA4JJ20X8qoDLSgRSMKrfBvNdqJcJ47A6HOX7G2o=
+github.com/turbot/steampipe-plugin-sdk/v6 v6.0.0/go.mod h1:CIMDhrEuWC9+x+y1fOBdWnCHFCDHKBfob7aNOlNoJbY=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/turbot/steampipe-plugin-scaleway/scaleway"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func main() {

--- a/scaleway/connection_config.go
+++ b/scaleway/connection_config.go
@@ -1,7 +1,7 @@
 package scaleway
 
 import (
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 type scalewayConfig struct {
@@ -17,9 +17,9 @@ func ConfigInstance() interface{} {
 
 // GetConfig :: retrieve and cast connection config from query data
 func GetConfig(connection *plugin.Connection) scalewayConfig {
-	if connection == nil || connection.Config == nil {
+	if connection == nil {
 		return scalewayConfig{}
 	}
-	config, _ := connection.Config.(scalewayConfig)
+	config, _ := connection.GetConfig().(scalewayConfig)
 	return config
 }

--- a/scaleway/multi_region.go
+++ b/scaleway/multi_region.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 // Regions is the current known list of valid regions

--- a/scaleway/plugin.go
+++ b/scaleway/plugin.go
@@ -3,8 +3,8 @@ package scaleway
 import (
 	"context"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 const pluginName = "steampipe-plugin-scaleway"

--- a/scaleway/service.go
+++ b/scaleway/service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 // getSessionConfig :: returns Scaleway client to perform API requests

--- a/scaleway/table_scaleway_account_project.go
+++ b/scaleway/table_scaleway_account_project.go
@@ -7,9 +7,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/account/v3"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_account_ssh_key.go
+++ b/scaleway/table_scaleway_account_ssh_key.go
@@ -6,9 +6,9 @@ import (
 	account "github.com/scaleway/scaleway-sdk-go/api/account/v2alpha1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_baremetal_server.go
+++ b/scaleway/table_scaleway_baremetal_server.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/baremetal/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_billing_consumption.go
+++ b/scaleway/table_scaleway_billing_consumption.go
@@ -7,9 +7,9 @@ import (
 	billing "github.com/scaleway/scaleway-sdk-go/api/billing/v2beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_billing_invoice.go
+++ b/scaleway/table_scaleway_billing_invoice.go
@@ -8,9 +8,9 @@ import (
 	billing "github.com/scaleway/scaleway-sdk-go/api/billing/v2beta1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableScalewayBillingInvoice(ctx context.Context) *plugin.Table {

--- a/scaleway/table_scaleway_iam_api_key.go
+++ b/scaleway/table_scaleway_iam_api_key.go
@@ -6,9 +6,9 @@ import (
 	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_iam_user.go
+++ b/scaleway/table_scaleway_iam_user.go
@@ -6,9 +6,9 @@ import (
 	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_instance_image.go
+++ b/scaleway/table_scaleway_instance_image.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_instance_ip.go
+++ b/scaleway/table_scaleway_instance_ip.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_instance_security_group.go
+++ b/scaleway/table_scaleway_instance_security_group.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_instance_server.go
+++ b/scaleway/table_scaleway_instance_server.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_instance_snapshot.go
+++ b/scaleway/table_scaleway_instance_snapshot.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_instance_volume.go
+++ b/scaleway/table_scaleway_instance_volume.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_kubernetes_cluster.go
+++ b/scaleway/table_scaleway_kubernetes_cluster.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/k8s/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_kubernetes_node.go
+++ b/scaleway/table_scaleway_kubernetes_node.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/k8s/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_kubernetes_pool.go
+++ b/scaleway/table_scaleway_kubernetes_pool.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/k8s/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_object_bucket.go
+++ b/scaleway/table_scaleway_object_bucket.go
@@ -7,9 +7,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_rdb_database.go
+++ b/scaleway/table_scaleway_rdb_database.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/rdb/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_rdb_instance.go
+++ b/scaleway/table_scaleway_rdb_instance.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/rdb/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_registry_image.go
+++ b/scaleway/table_scaleway_registry_image.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/registry/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_registry_namespace.go
+++ b/scaleway/table_scaleway_registry_namespace.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/registry/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/table_scaleway_vpc_private_network.go
+++ b/scaleway/table_scaleway_vpc_private_network.go
@@ -6,9 +6,9 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/vpc/v1"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/scaleway/utils.go
+++ b/scaleway/utils.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/turbot/go-kit/types"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func handleNilString(_ context.Context, d *transform.TransformData) (interface{}, error) {


### PR DESCRIPTION
## Description

Moves the plugin from steampipe-plugin-sdk v5.14.0 to v6.0.0.

v6.0.0 has one breaking change for plugin authors: `plugin.Connection.Config` is no longer exported ([sdk#938](https://github.com/turbot/steampipe-plugin-sdk/pull/938)), since direct field access raced the SDK's connection-update goroutine. Connection config is now read through the `Connection.GetConfig()` accessor.

Two commits:

1. **Migrate plugin to steampipe-plugin-sdk v6.0.0**: rewrites the `steampipe-plugin-sdk/v5` import paths to `/v6` across 28 files, and adapts the single `Connection.Config` read, in `scaleway/connection_config.go`.
2. **Update turbot/go-kit to v1.3.1**: the plugin was still pinned to v1.1.0, the version the SDK itself requires. This one is independent of the migration, so feel free to drop the commit if you'd rather it came through dependabot.

### On the GetConfig() call

`GetConfig()` is called once rather than once per branch:

```go
func GetConfig(connection *plugin.Connection) scalewayConfig {
	if connection == nil {
		return scalewayConfig{}
	}
	config, _ := connection.GetConfig().(scalewayConfig)
	return config
}
```

A literal translation would keep a `connection.GetConfig() == nil` check alongside the assertion, but that takes the `RWMutex` twice and lets the nil check and the type assertion observe two different values if the config is rotated in between, which is the race v6 set out to fix. A nil config fails the type assertion anyway and yields the same zero-value `scalewayConfig`, so behaviour is unchanged.

### On go-kit

The plugin uses exactly one go-kit function, `types.SafeString` in `scaleway/utils.go`. It and the `CastString` it delegates to are byte-identical between v1.1.0 and v1.3.1, and the `types` package only gained `ToHumanisedString`. Transitively bumps `fsnotify` 1.7.0 to 1.9.0 and `go-reflector` 0.5.6 to 0.5.8.

## Verification

`go build ./...`, `go vet ./...` and `go test ./...` are all clean. (`go vet` as well as `go build`, since it also type-checks `_test.go` files, though this repo has none.)

No table definitions, columns or query behaviour change.

Built the plugin and loaded it under Steampipe v2.4.4. The connection reaches `ready`, and all 22 tables and 389 columns are served:

```
$ steampipe query "select count(distinct table_name) as tables, count(*) as columns from information_schema.columns where table_schema='scaleway';"
+--------+---------+
| tables | columns |
+--------+---------+
| 22     | 389     |
+--------+---------+
```

Then queried every table against the live Scaleway API with a real API key. Tables the key has scope for return rows; the rest fail with the API's own 403, which is unrelated to the migration.

# Example query results

<details>
  <summary>Results</summary>

Against the public image catalogue, which exercises the multi-zone matrix and paging over ~22k rows:

```
$ steampipe query "select zone, count(*) as images from scaleway_instance_image where public group by zone order by zone;"
+----------+--------+
| zone     | images |
+----------+--------+
| fr-par-1 | 2,735  |
| fr-par-2 | 3,034  |
| fr-par-3 | 2,451  |
| nl-ams-1 | 2,580  |
| nl-ams-2 | 2,459  |
| nl-ams-3 | 2,261  |
| pl-waw-1 | 2,481  |
| pl-waw-2 | 2,443  |
| pl-waw-3 | 2,240  |
+----------+--------+
```

```
$ steampipe query "select name, arch, zone, state from scaleway_instance_image where public and name = 'Ubuntu 24.04 Noble Numbat' order by zone limit 5;"
+---------------------------+--------+----------+-----------+
| name                      | arch   | zone     | state     |
+---------------------------+--------+----------+-----------+
| Ubuntu 24.04 Noble Numbat | arm64  | fr-par-1 | available |
| Ubuntu 24.04 Noble Numbat | x86_64 | fr-par-1 | available |
| Ubuntu 24.04 Noble Numbat | arm64  | fr-par-1 | available |
| Ubuntu 24.04 Noble Numbat | x86_64 | fr-par-1 | available |
| Ubuntu 24.04 Noble Numbat | x86_64 | fr-par-1 | available |
+---------------------------+--------+----------+-----------+
```

</details>
