### PR TITLE
Fix nil-pointer panics on API errors and with environment credentials

### DIFF
--- a/scaleway/service.go
+++ b/scaleway/service.go
@@ -49,7 +49,7 @@ func getSessionConfig(ctx context.Context, d *plugin.QueryData) (*scw.Client, er
 		return nil, fmt.Errorf("both access_key and secret_key must be configured")
 	}
 
-	opts = append(opts, scw.WithAuth(*scalewayConfig.AccessKey, *scalewayConfig.SecretKey))
+	opts = append(opts, scw.WithAuth(accessKey, secretKey))
 
 	// Create client
 	client, err := scw.NewClient(opts...)

--- a/scaleway/table_scaleway_account_ssh_key.go
+++ b/scaleway/table_scaleway_account_ssh_key.go
@@ -133,6 +133,7 @@ func listAccountSSHKeys(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		resp, err := accountApi.ListSSHKeys(req)
 		if err != nil {
 			plugin.Logger(ctx).Error("scaleway_instance.listAccountSSHKeys", "query_error", err)
+			return nil, err
 		}
 
 		for _, key := range resp.SSHKeys {

--- a/scaleway/table_scaleway_iam_api_key.go
+++ b/scaleway/table_scaleway_iam_api_key.go
@@ -135,6 +135,7 @@ func listIamAPIKeys(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 		resp, err := iamApi.ListAPIKeys(req)
 		if err != nil {
 			plugin.Logger(ctx).Error("scaleway_iam_api_key.listIamAPIKeys", "query_error", err)
+			return nil, err
 		}
 
 		for _, key := range resp.APIKeys {

--- a/scaleway/table_scaleway_iam_user.go
+++ b/scaleway/table_scaleway_iam_user.go
@@ -130,6 +130,7 @@ func listIamUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 		resp, err := iamApi.ListUsers(req)
 		if err != nil {
 			plugin.Logger(ctx).Error("scaleway_iam_user.listIamUsers", "query_error", err)
+			return nil, err
 		}
 
 		for _, key := range resp.Users {


### PR DESCRIPTION
## Description

Fixes four nil-pointer dereferences that turn ordinary API failures into plugin panics. Found while testing the plugin against a live account. Both commits are independent of #168 (the SDK v6 migration); this branch is cut from `main` and the two merge cleanly in either order.

### 1. List hydrates that log an error and carry on

`listAccountSSHKeys`, `listIamAPIKeys` and `listIamUsers` all have this shape:

```go
resp, err := accountApi.ListSSHKeys(req)
if err != nil {
    plugin.Logger(ctx).Error("...", "query_error", err)
}                                    // no return

for _, key := range resp.SSHKeys {   // resp is nil here
```

So any API error becomes a panic instead of the error:

```
Error: rpc error: code = Internal desc = ... hydrate function listAccountSSHKeys
failed with panic runtime error: invalid memory address or nil pointer dereference
```

`scaleway_account_ssh_key` hits this for real, since the account `v2alpha1` endpoint it calls now answers 404. The two IAM tables are latent: they panic the same way as soon as their call fails, which a key without the relevant permissions will do with a 403.

The fix is the missing `return nil, err`, which is what every other list hydrate in the plugin already does.

### 2. Environment variable credentials were never used

`getSessionConfig` loads `scw.LoadEnvProfile()` into `accessKey` / `secretKey`, then lets connection config override them, and then builds the client with:

```go
opts = append(opts, scw.WithAuth(*scalewayConfig.AccessKey, *scalewayConfig.SecretKey))
```

which ignores both locals and dereferences the connection config pointers directly. With credentials supplied only via `SCW_ACCESS_KEY` / `SCW_SECRET_KEY`, documented under "Credentials from Environment Variables" and in the resolution order in `docs/index.md`, those pointers are nil and every query panics.

Fixed by passing the resolved locals. Connection config still wins over the environment, which the checks immediately above already guarantee.

## Verification

`go build ./...`, `go vet ./...` and `go test ./...` are clean.

Built both `main` and this branch and ran them under Steampipe v2.4.4 against a real Scaleway account.

**Environment-variable credentials**, connection config carrying no `access_key` / `secret_key`:

```
# main
$ steampipe query "select count(*) as projects from scaleway_account_project;"
Error: rpc error: code = Internal desc = ... hydrate function listAccountProjects
failed with panic runtime error: invalid memory address or nil pointer dereference

# this branch
+----------+
| projects |
+----------+
| 6        |
+----------+
```

**`scaleway_account_ssh_key`**, credentials in the connection config:

```
# main
Error: rpc error: code = Internal desc = ... hydrate function listAccountSSHKeys
failed with panic runtime error: invalid memory address or nil pointer dereference

# this branch
Error: scaleway: scaleway-sdk-go: http error 404 Not Found: not found (SQLSTATE HV000)
```

The 404 is a separate matter (that endpoint looks retired, so `scaleway_account_ssh_key` may want moving to a current API), but surfacing it beats crashing on it. Happy to look at that in another PR if useful.

No regression on the tables that already worked: `scaleway_iam_user`, `scaleway_iam_api_key` and `scaleway_account_project` return the same counts before and after.
