### PR TITLE
Fix staticcheck ST1023 that fails lint on every PR

### DIFF
--- a/scaleway/table_scaleway_baremetal_server.go
+++ b/scaleway/table_scaleway_baremetal_server.go
@@ -177,7 +177,7 @@ func listBaremetalServers(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 		return nil, err
 	}
 
-	var zoneAvailable bool = false
+	zoneAvailable := false
 	for _, v := range baremetalZones {
 		if v == parseZoneData {
 			zoneAvailable = true


### PR DESCRIPTION
## Description

`golangci-lint run` fails on `main`, and has since 80b4962, on a single staticcheck finding:

```
scaleway/table_scaleway_baremetal_server.go:180:20: ST1023: should omit type bool from declaration; it will be inferred from the right-hand side (staticcheck)
	var zoneAvailable bool = false
	                  ^
1 issues:
* staticcheck: 1
```

The line itself has not changed. What changed is the linter: `.github/workflows/golangci-lint.yml` installs golangci-lint unpinned, so it now resolves to v2.13.2, whose staticcheck enforces ST1023. Combined with `only-new-issues: false`, that means this one stale line fails the lint job on **every** pull request, whatever the pull request actually touches, including the open dependabot ones.

The fix drops the redundant type and uses a short variable declaration, which is what the rest of the function already does:

```go
-	var zoneAvailable bool = false
+	zoneAvailable := false
```

## Verification

Run locally with golangci-lint v2.13.2, the version the workflow currently resolves to.

Before, on a clean checkout of `main`:

```
$ golangci-lint run --timeout=10m
scaleway/table_scaleway_baremetal_server.go:180:20: ST1023: should omit type bool from declaration; it will be inferred from the right-hand side (staticcheck)
	var zoneAvailable bool = false
	                  ^
1 issues:
* staticcheck: 1
$ echo $?
1
```

After, on this branch:

```
$ golangci-lint run --timeout=10m
0 issues.
$ echo $?
0
```

`go build ./...`, `go vet ./...` and `go test ./...` are also clean. No behaviour change: the variable is still a `bool` initialised to `false`.

This is cut from `main` and touches nothing else, so it merges independently of any other open PR.

You may also want to pin the golangci-lint version in the workflow, or set `only-new-issues: true`, so that a future linter release cannot red every open PR on pre-existing code. Happy to do either in a separate PR if useful.
